### PR TITLE
Update rustdoc-stripper dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ homepage = "http://gtk-rs.org/"
 name = "lgpl_docs"
 
 [dependencies]
-rustdoc-stripper = "0.1.6"
+rustdoc-stripper = "0.1.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtk-rs-lgpl-docs"
-version = "0.1.15"
+version = "0.1.16"
 authors = [
     "GTK+ Project Developers",
     "Gtk-rs Project Developers",


### PR DESCRIPTION
Linked to https://github.com/gtk-rs/gir/pull/946